### PR TITLE
fix: explicitly run with bash instead of sh for debian based OS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 CWD=`pwd`
 
 # Register semantic commits scripts execution path


### PR DESCRIPTION
Since on Debian based OS (like Ubuntu/Debian) /bin/sh shell is symlinked to dash , the syntax of the `install.sh` script will be wrong 