### PR TITLE
feat: add breaking change flag (-w), and new semantic types (ci, build, perf)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ New command -> what it does:
 * ```git style "commit message here"``` -> ```git commit -m 'style: commit message here'```
 * ```git test "commit message here"``` -> ```git commit -m 'test: commit message here'```
 * ```git localize "commit message here"``` -> ```git commit -m 'localize: commit message here'```
+* ```git ci "commit message here"``` -> ```git commit -m 'ci: commit message here'```
+* ```git build "commit message here"``` -> ```git commit -m 'build: commit message here'```
+* ```git perf "commit message here"``` -> ```git commit -m 'perf: commit message here'```
 
 If you would like to add an optional scope, as described [here](https://conventionalcommits.org/), use the '-s' flag and quote the scope message:
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ If you would like to add an optional scope, as described [here](https://conventi
 
 * ```git docs -s "scope here" "commit message here"``` -> ```git commit -m 'docs(scope here): commit message here'```
 
+If you want to draw attention to a breaking change, you can use the '-w' (warning) flag to append '!' to the type or scope:
+
+* ```git feat -w "drop support for Node 6"``` -> ```git commit -m 'feat!: drop support for Node 6'```
+* ```git feat -s "api" -w "send an email"``` -> ```git commit -m 'feat(api)!: send an email'```
+
 If you would still like to use your text editor for your commit messages
 you can omit the message, and do your commit message in your editor.
 

--- a/git-build
+++ b/git-build
@@ -1,0 +1,10 @@
+#!/bin/bash
+if [ -z "$1" ]
+  then
+    git commit -m "build: " -e
+  elif [ "$1" == "-s" ]
+  then
+    git commit -m "build(${2}): ${@:3}"
+  else
+    git commit -m "build: ${@}"
+fi

--- a/git-build
+++ b/git-build
@@ -1,10 +1,16 @@
 #!/bin/bash
-if [ -z "$1" ]
-  then
-    git commit -m "build: " -e
-  elif [ "$1" == "-s" ]
-  then
-    git commit -m "build(${2}): ${@:3}"
-  else
-    git commit -m "build: ${@}"
+scope=""
+bang=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s) scope="($2)"; shift 2 ;;
+    -w) bang="!"; shift 1 ;;
+    *) break ;;
+  esac
+done
+
+if [ -z "$1" ]; then
+  git commit -m "build${scope}${bang}: " -e
+else
+  git commit -m "build${scope}${bang}: ${*}"
 fi

--- a/git-chore
+++ b/git-chore
@@ -1,10 +1,16 @@
 #!/bin/bash
-if [ -z "$1" ]
-  then
-    git commit -m "chore: " -e
-  elif [ "$1" == "-s" ]
-  then
-    git commit -m "chore(${2}): ${@:3}"
-  else
-    git commit -m "chore: ${@}"
+scope=""
+bang=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s) scope="($2)"; shift 2 ;;
+    -w) bang="!"; shift 1 ;;
+    *) break ;;
+  esac
+done
+
+if [ -z "$1" ]; then
+  git commit -m "chore${scope}${bang}: " -e
+else
+  git commit -m "chore${scope}${bang}: ${*}"
 fi

--- a/git-ci
+++ b/git-ci
@@ -1,0 +1,10 @@
+#!/bin/bash
+if [ -z "$1" ]
+  then
+    git commit -m "ci: " -e
+  elif [ "$1" == "-s" ]
+  then
+    git commit -m "ci(${2}): ${@:3}"
+  else
+    git commit -m "ci: ${@}"
+fi

--- a/git-ci
+++ b/git-ci
@@ -1,10 +1,16 @@
 #!/bin/bash
-if [ -z "$1" ]
-  then
-    git commit -m "ci: " -e
-  elif [ "$1" == "-s" ]
-  then
-    git commit -m "ci(${2}): ${@:3}"
-  else
-    git commit -m "ci: ${@}"
+scope=""
+bang=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s) scope="($2)"; shift 2 ;;
+    -w) bang="!"; shift 1 ;;
+    *) break ;;
+  esac
+done
+
+if [ -z "$1" ]; then
+  git commit -m "ci${scope}${bang}: " -e
+else
+  git commit -m "ci${scope}${bang}: ${*}"
 fi

--- a/git-docs
+++ b/git-docs
@@ -1,10 +1,16 @@
 #!/bin/bash
-if [ -z "$1" ]
-  then
-    git commit -m "docs: " -e
-  elif [ "$1" == "-s" ]
-  then
-    git commit -m "docs(${2}): ${@:3}"
-  else
-    git commit -m "docs: ${@}"
+scope=""
+bang=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s) scope="($2)"; shift 2 ;;
+    -w) bang="!"; shift 1 ;;
+    *) break ;;
+  esac
+done
+
+if [ -z "$1" ]; then
+  git commit -m "docs${scope}${bang}: " -e
+else
+  git commit -m "docs${scope}${bang}: ${*}"
 fi

--- a/git-feat
+++ b/git-feat
@@ -1,10 +1,16 @@
 #!/bin/bash
-if [ -z "$1" ]
-  then
-    git commit -m "feat: " -e
-  elif [ "$1" == "-s" ]
-  then
-    git commit -m "feat(${2}): ${@:3}"
-  else
-    git commit -m "feat: ${@}"
+scope=""
+bang=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s) scope="($2)"; shift 2 ;;
+    -w) bang="!"; shift 1 ;;
+    *) break ;;
+  esac
+done
+
+if [ -z "$1" ]; then
+  git commit -m "feat${scope}${bang}: " -e
+else
+  git commit -m "feat${scope}${bang}: ${*}"
 fi

--- a/git-fix
+++ b/git-fix
@@ -1,10 +1,16 @@
 #!/bin/bash
-if [ -z "$1" ]
-  then
-    git commit -m "fix: " -e
-  elif [ "$1" == "-s" ]
-  then
-    git commit -m "fix(${2}): ${@:3}"
-  else
-    git commit -m "fix: ${@}"
+scope=""
+bang=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s) scope="($2)"; shift 2 ;;
+    -w) bang="!"; shift 1 ;;
+    *) break ;;
+  esac
+done
+
+if [ -z "$1" ]; then
+  git commit -m "fix${scope}${bang}: " -e
+else
+  git commit -m "fix${scope}${bang}: ${*}"
 fi

--- a/git-localize
+++ b/git-localize
@@ -1,10 +1,16 @@
 #!/bin/bash
-if [ -z "$1" ]
-  then
-    git commit -m "localize: " -e
-  elif [ "$1" == "-s" ]
-  then
-    git commit -m "localize(${2}): ${@:3}"
-  else
-    git commit -m "localize: ${@}"
+scope=""
+bang=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s) scope="($2)"; shift 2 ;;
+    -w) bang="!"; shift 1 ;;
+    *) break ;;
+  esac
+done
+
+if [ -z "$1" ]; then
+  git commit -m "localize${scope}${bang}: " -e
+else
+  git commit -m "localize${scope}${bang}: ${*}"
 fi

--- a/git-perf
+++ b/git-perf
@@ -1,0 +1,10 @@
+#!/bin/bash
+if [ -z "$1" ]
+  then
+    git commit -m "perf: " -e
+  elif [ "$1" == "-s" ]
+  then
+    git commit -m "perf(${2}): ${@:3}"
+  else
+    git commit -m "perf: ${@}"
+fi

--- a/git-perf
+++ b/git-perf
@@ -1,10 +1,16 @@
 #!/bin/bash
-if [ -z "$1" ]
-  then
-    git commit -m "perf: " -e
-  elif [ "$1" == "-s" ]
-  then
-    git commit -m "perf(${2}): ${@:3}"
-  else
-    git commit -m "perf: ${@}"
+scope=""
+bang=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s) scope="($2)"; shift 2 ;;
+    -w) bang="!"; shift 1 ;;
+    *) break ;;
+  esac
+done
+
+if [ -z "$1" ]; then
+  git commit -m "perf${scope}${bang}: " -e
+else
+  git commit -m "perf${scope}${bang}: ${*}"
 fi

--- a/git-refactor
+++ b/git-refactor
@@ -1,10 +1,16 @@
 #!/bin/bash
-if [ -z "$1" ]
-  then
-    git commit -m "refactor: " -e
-  elif [ "$1" == "-s" ]
-  then
-    git commit -m "refactor(${2}): ${@:3}"
-  else
-    git commit -m "refactor: ${@}"
+scope=""
+bang=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s) scope="($2)"; shift 2 ;;
+    -w) bang="!"; shift 1 ;;
+    *) break ;;
+  esac
+done
+
+if [ -z "$1" ]; then
+  git commit -m "refactor${scope}${bang}: " -e
+else
+  git commit -m "refactor${scope}${bang}: ${*}"
 fi

--- a/git-style
+++ b/git-style
@@ -1,10 +1,16 @@
 #!/bin/bash
-if [ -z "$1" ]
-  then
-    git commit -m "style: " -e
-  elif [ "$1" == "-s" ]
-  then
-    git commit -m "style(${2}): ${@:3}"
-  else
-    git commit -m "style: ${@}"
+scope=""
+bang=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s) scope="($2)"; shift 2 ;;
+    -w) bang="!"; shift 1 ;;
+    *) break ;;
+  esac
+done
+
+if [ -z "$1" ]; then
+  git commit -m "style${scope}${bang}: " -e
+else
+  git commit -m "style${scope}${bang}: ${*}"
 fi

--- a/git-test
+++ b/git-test
@@ -1,10 +1,16 @@
 #!/bin/bash
-if [ -z "$1" ]
-  then
-    git commit -m "test: " -e
-  elif [ "$1" == "-s" ]
-  then
-    git commit -m "test(${2}): ${@:3}"
-  else
-    git commit -m "test: ${@}"
+scope=""
+bang=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s) scope="($2)"; shift 2 ;;
+    -w) bang="!"; shift 1 ;;
+    *) break ;;
+  esac
+done
+
+if [ -z "$1" ]; then
+  git commit -m "test${scope}${bang}: " -e
+else
+  git commit -m "test${scope}${bang}: ${*}"
 fi

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,31 @@
+Function Register-GitAlias {
+    param (
+        [string]$AliasName,
+        [string]$Type = ""
+    )
+    
+    if (-not $Type) { $Type = $AliasName }
+
+    $bashScript = "!f() { [[ -z `"`$GIT_PREFIX`" ]] || cd `"`$GIT_PREFIX`"; local scope=`"`" bang=`"`"; while [[ `$# -gt 0 ]]; do case `"`$1`" in -s) scope=`"(`$2)`"; shift 2 ;; -w) bang=`"!`"; shift 1 ;; *) break ;; esac; done; if [ -z `"`$1`" ]; then git commit -m `"$Type`${scope}${bang}: `" -e; else git commit -m `"$Type`${scope}${bang}: `${*}`"; fi }; f"
+
+    git config --global alias.$AliasName $bashScript
+}
+
+Write-Host "Installing git aliases..."
+
+$semanticAliases = @("chore", "docs", "feat", "fix", "localize", "refactor", "style", "test", "ci", "build", "perf")
+
+foreach ($alias in $semanticAliases) {
+    Register-GitAlias -AliasName $alias
+}
+
+try {
+    if (Get-Command "git-extras" -ErrorAction SilentlyContinue) {
+        Register-GitAlias -AliasName "ch" -Type "chore"
+        Register-GitAlias -AliasName "rf" -Type "refactor"
+    }
+} catch {}
+
+Write-Host
+Write-Host 'Done! Now you can use semantic commits.'
+Write-Host 'See: https://github.com/pallax03/git-semantic-commits for more information.'

--- a/install.sh
+++ b/install.sh
@@ -57,7 +57,7 @@ if [[ -n $1 ]] && [[ $1 == '--scripts' ]]; then
 else
   echo 'Installing git aliases…'
 
-  semantic_aliases=( 'chore' 'docs' 'feat' 'fix' 'localize' 'chore' 'refactor' 'style' 'test' )
+  semantic_aliases=( 'chore' 'docs' 'feat' 'fix' 'localize' 'chore' 'refactor' 'style' 'test' 'ci' 'build' 'perf' )
 
   for semantic_alias in "${semantic_aliases[@]}"; do
     register_git_alias $semantic_alias

--- a/install.sh
+++ b/install.sh
@@ -22,14 +22,8 @@ function register_path {
 # $1 — git alias and semantic message prefix
 # [$2] — (optional) custom semantic message prefix
 function register_git_alias {
-  if ! git config --global --get-all alias.$1 &>/dev/null; then
-    if [[ -z $2 ]]; then
-      git config --global alias.$1 '!f() { [[ -z "$GIT_PREFIX" ]] || cd "$GIT_PREFIX" && if [ -z "$1" ]; then git commit -m "'$1': " -e; elif [ "$1" == "-s" ]; then git commit -m "'$1'(${2}): ${@:3}"; else git commit -m "'$1': ${@}"; fi }; f'
-
-    else
-      git config --global alias.$1 '!f() { [[ -z "$GIT_PREFIX" ]] || cd "$GIT_PREFIX" && if [ -z "$1" ]; then git commit -m "'$2': " -e; elif [ "$1" == "-s" ]; then git commit -m "'$2'(${2}): ${@:3}"; else git commit -m "'$2': ${@}"; fi }; f'
-    fi
-  fi
+  local type="${2:-$1}"
+  git config --global alias.$1 '!f() { [[ -z "$GIT_PREFIX" ]] || cd "$GIT_PREFIX"; local scope="" bang=""; while [[ $# -gt 0 ]]; do case "$1" in -s) scope="($2)"; shift 2 ;; -w) bang="!"; shift 1 ;; *) break ;; esac; done; if [ -z "$1" ]; then git commit -m "'$type'${scope}${bang}: " -e; else git commit -m "'$type'${scope}${bang}: ${*}"; fi }; f'
 }
 
 # Check if command was finished successfully


### PR DESCRIPTION
This pull request introduces new semantic git commit types (`ci`, `build`, and `perf`), and refactors all semantic commit scripts to support optional scope and breaking change flags in a consistent way. Additionally, the installation process and documentation are updated to reflect these enhancements. The main improvements are grouped below.

**New commit types and script additions:**

* Added new semantic commit scripts: `git-ci`, `git-build`, and `git-perf`, each supporting optional scope (`-s`) and breaking change (`-w`) flags.
* Updated the installation script to register these new aliases automatically.

**Refactoring and consistency improvements:**

* Refactored all existing semantic commit scripts (`git-chore`, `git-docs`, `git-feat`, `git-fix`, `git-localize`, `git-refactor`, `git-style`, `git-test`) to use a unified approach for handling scope and breaking change flags, improving maintainability and user experience.
* Updated the git alias registration logic in `install.sh` to match the new script logic, ensuring aliases support both scope and breaking change flags.

**Documentation updates:**

* Expanded the `README.md` to document the new commit types and explain the usage of the `-s` (scope) and `-w` (breaking change) flags for all semantic commit commands.